### PR TITLE
Bind flask app to 0.0.0.0

### DIFF
--- a/file.py
+++ b/file.py
@@ -19,4 +19,4 @@ def valid_login(email, password):
 
 
 if __name__ == "__main__":
-    app.run(host="localhost", port=5000)
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
Change bind address of flask app to 0.0.0.0 instead of localhost to allow external access to the docker container

Otherwise the container can be accessed only to itself and therefore is useless.
Accessbility from outside to the docker host is controlled by container launch parameters.